### PR TITLE
"visible" gardens

### DIFF
--- a/layouts/_partials/pages-hierarchy.html
+++ b/layouts/_partials/pages-hierarchy.html
@@ -2,37 +2,40 @@
     with links to each page
     TODO: eventually replace this with proper nested lists,
         possibly with collapsible sections?
+    TODO: don't list pages where an ancestor is not published (e.g. ephesos/example.md is draft:false, but ephesos/_index.md is draft:true)
 */}}
 <ul>
     {{ $indent := 0 }}
     {{ $seen := slice }}
     {{ range sort . ".Path" "asc" }}
-        {{ range $i, $p := .Ancestors.Reverse }}
-            {{ $indent = add $i 1 }}
-            {{ if not (or (in $seen .Path ) (lt $i 2)) }}
-                {{ $class := "" }}
-                {{ if eq .Type "place"}}{{ $class = "place" }}{{ end }}
-                {{ if eq $i 2 }}{{ $class = print $class " province" }}{{ end }}
-                <li style="margin-left: {{ mul 2 $i }}em"{{ with $class }} class="{{ . }}"{{ end }}>
-                    {{ if .Title }}
-                        {{ .Title }}
-                    {{ else }}
-                        {{/* if no _index.md content, infer title from path */}}
-                        [{{ index (split .Path "/") $i }}]
-                    {{ end  }}
-                </li>
-                {{ $seen = $seen | append .Path }}
+        {{ if (partial "visible.html" .) }}
+            {{ range $i, $p := .Ancestors.Reverse }}
+                {{ $indent = add $i 1 }}
+                {{ if not (or (in $seen .Path ) (lt $i 2)) }}
+                    {{ $class := "" }}
+                    {{ if eq .Type "place"}}{{ $class = "place" }}{{ end }}
+                    {{ if eq $i 2 }}{{ $class = print $class " province" }}{{ end }}
+                    <li style="margin-left: {{ mul 2 $i }}em"{{ with $class }} class="{{ . }}"{{ end }}>
+                        {{ if .Title }}
+                            {{ .Title }}{{ if .Draft }} (draft){{ end }}
+                        {{ else }}
+                            {{/* if no _index.md content, infer title from path */}}
+                            [{{ index (split .Path "/") $i }}]
+                        {{ end  }}
+                    </li>
+                    {{ $seen = $seen | append .Path }}
+                {{ end }}
             {{ end }}
+            {{ $class := "" }}
+            {{ if eq .Type "place" }}
+                {{ $seen = $seen | append .Path }}
+                {{ $class = "place" }}
+                {{ if eq $indent 2 }}{{ $class = (print $class " province") }}
+                {{end}}
+            {{ end }}
+            <li style="margin-left: {{ mul 2 $indent }}em"{{ with $class }} class="{{ . }}"{{ end }}>
+                <a href="{{ .Permalink }}">{{ .Title }}</a> {{ if .Draft }} (draft){{ end }}
+            </li>
         {{ end }}
-        {{ $class := "" }}
-        {{ if eq .Type "place" }}
-            {{ $seen = $seen | append .Path }}
-            {{ $class = "place" }}
-            {{ if eq $indent 2 }}{{ $class = (print $class " province") }}
-            {{end}}
-        {{ end }}
-        <li style="margin-left: {{ mul 2 $indent }}em"{{ with $class }} class="{{ . }}"{{ end }}>
-            <a href="{{ .Permalink }}">{{ .Title }}</a>
-        </li>
     {{ end }}
 </ul>

--- a/layouts/_partials/search-index.html
+++ b/layouts/_partials/search-index.html
@@ -1,10 +1,11 @@
 <!-- This file builds the search index
      This actual search is done in search.js -->
 <script>
-// build the search index from each garden page (TODO: include place pages -- but how to display in results?)
+// build the search index from each visible garden page
+// TODO: include place pages? -- but how to differentiate in results?
 window.pageData = {
 {{ range $ri, $rv := where (sort .Site.Pages "Path") "Type" "garden" }}
-    {{ if .Title }}
+    {{ if partial "visible.html" . }}
         {{/* add path (province, location) and frontmatter (author, contributor) to fulltext */}}
         {{ $place := title (replaceRE "[\\W_]+" " " .Path) }}
         {{ $content := print .Plain $place " Author: " .Params.Author " Contributor: " .Params.Contributor " " }}

--- a/layouts/_partials/visible.html
+++ b/layouts/_partials/visible.html
@@ -1,0 +1,21 @@
+{{/*
+This is a replacement for SITE.BuildDrafts, which was deprecated in Hugo v0.156.0
+
+We use in pages-hierarchy.html, to allow a folder/_index.md with draft:true
+to suppress any descendant pages, even if they are draft:false.
+*/}}
+{{ $buildDrafts := false }}
+{{ range hugo.Sites.Default.Pages }}
+    {{ if .Draft }}
+        {{ $buildDrafts = true }}
+    {{ end }}
+{{ end }}
+{{ $visible := true }}
+{{ if not $buildDrafts }}
+    {{ range .Ancestors }}
+        {{ if .Draft }}
+            {{ $visible = false }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+{{ return $visible }}

--- a/layouts/people/single.html
+++ b/layouts/people/single.html
@@ -22,9 +22,7 @@
         {{/* list authored garden and place pages */}}
         {{ $pages := where (where .Site.RegularPages ".Params.Author" "like" $person) ".Type" "garden" }}
         {{ $places := where (where .Site.Pages ".Params.Author" "like" $person) ".Type" "place" }}
-        {{ range $places }}
-            {{ $pages = $pages | append . }}
-        {{ end }}
+        {{ $pages = $pages | union $places }}
         {{ if $pages }}
             <hr>
             <h2>Author of</h2>
@@ -36,9 +34,7 @@
         {{/* list contributions to garden and place pages */}}
         {{ $pages := where (where .Site.RegularPages ".Params.Contributor" "like" $person) ".Type" "garden" }}
         {{ $places := where (where .Site.Pages ".Params.Contributor" "like" $person) ".Type" "place" }}
-        {{ range $places }}
-            {{ $pages = $pages | append . }}
-        {{ end }}
+        {{ $pages = $pages | union $places }}
         {{ if $pages }}
             <hr>
             <h2>Contributor to</h2>

--- a/layouts/place/list.html
+++ b/layouts/place/list.html
@@ -23,10 +23,17 @@
 
     <!-- Find all garden articles under this location -->
     {{- $pages := where (sort page.RegularPagesRecursive ".Path") "Type" "garden" -}}
+    <!-- visible gardens have no ancestors with draft:true -->
+    {{ $visible := slice }}
+    {{ range $pages }}
+        {{ if partial "visible.html" . }}
+            {{ $visible = $visible | append . }}
+        {{ end }}
+    {{ end }}
 
     <!-- State how many published/total  -->
-    {{- $count := len $pages -}}
-    {{- $countpublished := len (where $pages "Params.draft" false ) -}}    
+    {{- $count := len $visible -}}
+    {{- $countpublished := len (where $visible "Params.draft" false ) -}}    
     <div class='summary'>
         {{ $countpublished }}{{ if ne $count $countpublished }}/{{ $count }}{{ end }}
         garden article{{ if ne $countpublished 1 }}s{{ end }}
@@ -35,8 +42,8 @@
         been published{{ if ne $countpublished 0 }}:{{ end }}
     </div>
 
-    <!-- List each garden -->
-    {{- range $pages -}}
+    <!-- List each visible garden -->
+    {{- range $visible -}}
         {{- .Render "summary" -}}
     {{- end -}}
 </main>


### PR DESCRIPTION
Gardens should only be visible on the public website if:
- the garden is `draft: false`
- all containing places up the hierarchy are `draft: false`

This PR creates a new "visible.html" partial that is used when displaying list of gardens by place, by people, and by search.