### PR TITLE
orange dots and links for drafts

### DIFF
--- a/layouts/_partials/pages-hierarchy.html
+++ b/layouts/_partials/pages-hierarchy.html
@@ -17,7 +17,7 @@
                     {{ if eq $i 2 }}{{ $class = print $class " province" }}{{ end }}
                     <li style="margin-left: {{ mul 2 $i }}em"{{ with $class }} class="{{ . }}"{{ end }}>
                         {{ if .Title }}
-                            {{ .Title }}{{ if .Draft }} (draft){{ end }}
+                            {{ .Title }}{{ if .Draft }} (DRAFT){{ end }}
                         {{ else }}
                             {{/* if no _index.md content, infer title from path */}}
                             [{{ index (split .Path "/") $i }}]
@@ -34,7 +34,7 @@
                 {{end}}
             {{ end }}
             <li style="margin-left: {{ mul 2 $indent }}em"{{ with $class }} class="{{ . }}"{{ end }}>
-                <a href="{{ .Permalink }}">{{ .Title }}</a> {{ if .Draft }} (draft){{ end }}
+                <a href="{{ .Permalink }}">{{ .Title }}</a> {{ if .Draft }} (DRAFT){{ end }}
             </li>
         {{ end }}
     {{ end }}

--- a/layouts/_partials/pages-hierarchy.html
+++ b/layouts/_partials/pages-hierarchy.html
@@ -17,7 +17,7 @@
                     {{ if eq $i 2 }}{{ $class = print $class " province" }}{{ end }}
                     <li style="margin-left: {{ mul 2 $i }}em"{{ with $class }} class="{{ . }}"{{ end }}>
                         {{ if .Title }}
-                            {{ .Title }}{{ if .Draft }} (DRAFT){{ end }}
+                            {{ .Title }}{{ if .Draft }} <span class="draft">draft</span>{{ end }}
                         {{ else }}
                             {{/* if no _index.md content, infer title from path */}}
                             [{{ index (split .Path "/") $i }}]

--- a/layouts/_partials/pages-hierarchy.html
+++ b/layouts/_partials/pages-hierarchy.html
@@ -34,7 +34,7 @@
                 {{end}}
             {{ end }}
             <li style="margin-left: {{ mul 2 $indent }}em"{{ with $class }} class="{{ . }}"{{ end }}>
-                <a href="{{ .Permalink }}">{{ .Title }}</a> {{ if .Draft }} (DRAFT){{ end }}
+                <a href="{{ .Permalink }}">{{ .Title }}</a>{{ if .Draft }} <span class="draft">draft</span>{{ end }}
             </li>
         {{ end }}
     {{ end }}

--- a/layouts/_partials/widgets/map.html
+++ b/layouts/_partials/widgets/map.html
@@ -176,14 +176,20 @@
             markers = [];
             bounds = L.latLngBounds();
             let div_circle = L.divIcon({ className: 'dot' })
+            let div_circle_draft = L.divIcon({ className: 'dot draft' })
             
             function addPoint(p) {
                 // only add point if lat/lon are both not 0
                 if (p.latlon[0] && p.latlon[1]) {
-                    marker = L.marker(p.latlon, { icon: div_circle });
+                    if (p.draft) {
+                        marker = L.marker(p.latlon, { icon: div_circle_draft });
+                    }
+                    else {
+                        marker = L.marker(p.latlon, { icon: div_circle });
+                    }
                     marker.bindPopup(`
                         <div class='smallcrumbs'>${p.smallcrumbs}</div>
-                        <a href='${p.url}'>${p.title}</a>
+                        <a href='${p.url}'${ p.draft ? " class='draft'" : ''}>${p.title}</a>${ p.draft ? ' (DRAFT)' : ''}
                     `);
                     marker.addTo(map);
                     markers.push(marker);
@@ -216,7 +222,8 @@
                         "latlon": {{ .Params.latlon }},
                         "smallcrumbs": {{ partial "smallcrumbs.html" . }},
                         "title": {{ .Title }},
-                        "url": {{ .Permalink }}
+                        "url": {{ .Permalink }},
+                        "draft": {{ .Draft }}
                     })
                 {{ end }}
             {{ end }}

--- a/layouts/_partials/widgets/map.html
+++ b/layouts/_partials/widgets/map.html
@@ -182,7 +182,7 @@
                 // only add point if lat/lon are both not 0
                 if (p.latlon[0] && p.latlon[1]) {
                     if (p.draft) {
-                        marker = L.marker(p.latlon, { icon: div_circle_draft });
+                        marker = L.marker(p.latlon, { icon: div_circle_draft, zIndexOffset: -9999 });
                     }
                     else {
                         marker = L.marker(p.latlon, { icon: div_circle });

--- a/layouts/_partials/widgets/map.html
+++ b/layouts/_partials/widgets/map.html
@@ -189,7 +189,7 @@
                     }
                     marker.bindPopup(`
                         <div class='smallcrumbs'>${p.smallcrumbs}</div>
-                        <a href='${p.url}'${ p.draft ? " class='draft'" : ''}>${p.title}</a>${ p.draft ? ' (DRAFT)' : ''}
+                        <a href='${p.url}'>${p.title}</a>${ p.draft ? ' <span class="draft">draft</span>' : ''}
                     `);
                     marker.addTo(map);
                     markers.push(marker);

--- a/layouts/meta/list.html
+++ b/layouts/meta/list.html
@@ -24,7 +24,7 @@
             <tr {{ if $p.Draft }}class="draft"{{ end }}>
                 <td class="path"><a href="{{ .Permalink }}">{{ replace $p.Path "/place" "" }}</a></td>
                 <td class="title">{{ $p.Title }}
-                    {{ if $p.Draft }}<b>(DRAFT)</b>{{ end }}
+                    {{ if $p.Draft }}<span class="draft">draft</span>{{ end }}
                 </td>
                 <td>{{ htmlUnescape (replace $p.Params.Author ", " ",<br>") | safeHTML }}</td>
                 <td>{{ htmlUnescape (replace $p.Params.Contributor ", " ",<br>") | safeHTML }}</td>
@@ -53,7 +53,7 @@
                 <td>{{ $p.Param "jashemski-catalogue" }}</td>
                 <td class="path"><a href="{{ .Permalink }}">{{ replace $p.Path "/place" "" }}</a></td>
                 <td class="title">{{ $p.Title }}
-                    {{ if $p.Draft }}<b>(DRAFT)</b>{{ end }}
+                    {{ if $p.Draft }}<span class="draft">draft</span>{{ end }}
                 </td>
                 <td class="nowrap">{{ htmlUnescape (replace $p.Params.Author ", " ",<br>") | safeHTML }}</td>
                 <td class="nowrap">{{ htmlUnescape (replace $p.Params.Contributor ", " ",<br>") | safeHTML }}</td>

--- a/layouts/summary.html
+++ b/layouts/summary.html
@@ -6,10 +6,10 @@
                 {{- partial "smallcrumbs.html" . }}
             </div>
             <h3 class="list__title post__title">
-                <a href="{{ .Permalink }}" rel="bookmark"{{ if .Params.draft }} class="draft"{{ end }}>
+                <a href="{{ .Permalink }}">
                 {{ .Title }}
                 </a>
-                {{- if .Params.draft }} (DRAFT) {{- end }}
+                {{- if .Params.draft }}<span class="draft">draft</span>{{- end }}
             </h3>
             {{ with partial "post_meta.html" . -}}
             <div class="list__meta meta">{{ . }}</div>

--- a/layouts/summary.html
+++ b/layouts/summary.html
@@ -6,7 +6,7 @@
                 {{- partial "smallcrumbs.html" . }}
             </div>
             <h3 class="list__title post__title">
-                <a href="{{ .Permalink }}" rel="bookmark">
+                <a href="{{ .Permalink }}" rel="bookmark"{{ if .Params.draft }} class="draft"{{ end }}>
                 {{ .Title }}
                 </a>
                 {{- if .Params.draft }} (DRAFT) {{- end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -31,6 +31,9 @@ a.id {
 .post__title a {
   color: #282;
 }
+.post__title a.draft {
+  color: #f80;
+}
 
 blockquote {
   border-left: 4px solid #ccc;
@@ -273,11 +276,14 @@ article.list__item em {
 
 #map .dot {
   background: #282;
-  border: 0.5px solid #aea;
+  border: 0.5px solid #eee;
   border-radius: 50%;
   box-shadow: 1px 2px rgb(0 0 0 / 50%);
   height: 10px ! important;
   width: 10px ! important;
+}
+#map .dot.draft {
+  background:#f80;
 }
 
 #map .leaflet-popup-content a {
@@ -285,6 +291,9 @@ article.list__item em {
   font-family: "Candara", Arial, sans-serif;
   font-size: 1rem;
   font-weight: bold;
+}
+#map .leaflet-popup-content a.draft {
+  color: #f80;
 }
 
 #map .leaflet-popup-content a.smallcrumbs {
@@ -349,7 +358,7 @@ article.list__item em {
   text-align: right;
 }
 
-.draft {
+article.draft {
   background: #fff2e7;
 }
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -32,7 +32,7 @@ a.id {
   color: #282;
 }
 .post__title a.draft {
-  color: #f80;
+  color: #d70;
 }
 
 blockquote {
@@ -286,18 +286,20 @@ article.list__item em {
   background:#f80;
 }
 
+#map .leaflet-popup-content {
+  font-family: "Candara", Arial, sans-serif;
+  font-size: 1rem;
+}
+
 #map .leaflet-popup-content a {
   color: #282;
-  font-family: "Candara", Arial, sans-serif;
   font-size: 1rem;
   font-weight: bold;
 }
-#map .leaflet-popup-content a.draft {
-  color: #f80;
-}
 
-#map .leaflet-popup-content a.smallcrumbs {
+#map .leaflet-popup-content .smallcrumbs {
   color: #c22d30;
+  font-size: 0.8rem;
 }
 
 #search-results-summary {
@@ -329,10 +331,28 @@ article.list__item em {
   margin-top: 1em;
 }
 
+.people-gardens a {
+  color: #282;
+}
+
+.people-gardens li.place a {
+  color: #c22d30;
+}
+
+span.draft {
+  background: #f80;
+  color: #fff;
+  font-family: "Arial", sans-serif;
+  font-size: 70%;
+  font-weight: normal;
+  padding: 0 0.5em;
+  border-radius: 0.5em;
+}
+
 .smallcrumbs {
   font-family: "Candara", "Arial", sans-serif;
   color: #c22d30;
-  font-size: 100%;
+  font-size: 1rem;
   margin: 0;
   line-height: 1.0;
 }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -14,8 +14,8 @@ function displayResults (qterms, results, pageData) {
       resultList += '<div class="smallcrumbs">' + item.smallcrumbs + '</div>'
 
       // linked title
-      resultList += '<h3 class="list__title post__title"><a href="' + item.url + '">' + item.title + '</a>' +
-       (item.draft? ' (DRAFT)' : '') + '</h3>'
+      resultList += '<h3 class="list__title post__title"><a href="' + item.url + '">' +
+       item.title + '</a>' + (item.draft ? ' <span class="draft">draft</span>' : '') + '</h3>'
 
       // normalize diacritics for better snippet matching
       let content = item.content.normalize("NFD").replace(/[\u0300-\u036f]/g, "")


### PR DESCRIPTION
This PR uses a consistent orange color for draft gardens.
- drafts appear as orange dots on map (below published green points)
- orange "draft" label on map popups
- orange "draft" label in lists by place or by search
- orange "draft" label in people contribution lists